### PR TITLE
fix(theme): :label: add missing Gradient types

### DIFF
--- a/lib/types/theme.ts
+++ b/lib/types/theme.ts
@@ -137,6 +137,8 @@ interface Blurs {
 
 interface LinearGradient {
   background: CSS.Property.Background;
+  colors: CSS.Property.Color[];
+  angle: number;
 }
 
 // interface MeshGradient {


### PR DESCRIPTION
Simple PR adding some missing types. Not sure why TS hadn't complained about them yet.