### PR TITLE
feat(input-box): :lipstick: add support for required prop and adjust styles

### DIFF
--- a/lib/components/CheckBoxGroup/__snapshots__/CheckBoxGroup.test.tsx.snap
+++ b/lib/components/CheckBoxGroup/__snapshots__/CheckBoxGroup.test.tsx.snap
@@ -13,9 +13,11 @@ exports[`CheckBoxGroup Component > should match snapshot 1`] = `
           color="neutral"
           for="pebbles__input__1"
           type="overlineXSmall"
-        />
+        >
+           
+        </label>
         <div
-          class="sc-iveFHk jnTCMt"
+          class="sc-bBABsx gBzJtW"
         >
           <div
             style="padding: 10px 12px;"
@@ -90,9 +92,11 @@ exports[`CheckBoxGroup Component > should match snapshot 1`] = `
         color="neutral"
         for="pebbles__input__1"
         type="overlineXSmall"
-      />
+      >
+         
+      </label>
       <div
-        class="sc-iveFHk jnTCMt"
+        class="sc-bBABsx gBzJtW"
       >
         <div
           style="padding: 10px 12px;"

--- a/lib/components/InputBox/BaseInputBox.styled.ts
+++ b/lib/components/InputBox/BaseInputBox.styled.ts
@@ -18,25 +18,32 @@ export const StyledDiv = styled.div<{
     spaceAfter ? theme.spacings?.[spaceAfter as spacingTokens] : 0};
 `;
 
-export const HelperDiv = styled.div`
+export const HelperDiv = styled.div<{ destructive?: boolean }>`
   display: flex;
-  margin-top: ${({ theme }) => theme.spacings.xxsm};
-  margin-left: ${({ theme }) => theme.spacings.xxsm};
+  align-items: center;
+  margin-top: ${({ theme }) => theme.spacings.xsm};
+
+  color: ${({ theme, destructive }) =>
+    destructive
+      ? theme.inputBox.destructive.helperColor
+      : theme.inputBox.info.helperColor};
 `;
 
-export const Helper = styled(Text)<Pick<BaseInputBoxProps, "status">>`
-  color: ${({ theme }) => theme.inputBox.helper.color};
-  font-size: ${({ theme }) => theme.inputBox.helper.fontSize};
-  font-style: ${({ theme }) => theme.inputBox.helper.fontStyle};
-  font-weight: ${({ theme }) => theme.inputBox.helper.fontWeight};
-  line-height: ${({ theme }) => theme.inputBox.helper.lineHeight};
-  text-transform: none;
-`;
-
-export const HelperIcon = styled.div<Pick<BaseInputBoxProps, "status">>`
+export const HelperIcon = styled.div<{ destructive?: boolean }>`
+  display: flex;
+  align-items: center;
   margin-right: ${({ theme }) => theme.inputBox.helper.margin};
 
-  color: ${({ theme }) => theme.inputBox.helper.color};
+  color: ${({ theme, destructive }) =>
+    destructive
+      ? theme.inputBox.destructive.helperColor
+      : theme.inputBox.info.helperColor};
+  font-size: 16px;
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
 `;
 
 export const HintDiv = styled.div`
@@ -46,12 +53,12 @@ export const HintDiv = styled.div`
   right: 16px;
   flex-direction: row;
   align-items: center;
-  height: 50px;
+  height: 40px;
 `;
 
 export const Hint = styled(Text)<Pick<BaseInputBoxProps, "disabled">>`
   color: ${({ theme, disabled }) =>
-    disabled ? theme.colors.neutral[300] : theme.inputBox.helper.color};
+    disabled ? theme.colors.neutral[300] : theme.inputBox.info.helperColor};
 `;
 
 export const HintIconWrapper = styled.div<Pick<BaseInputBoxProps, "disabled">>`
@@ -68,9 +75,7 @@ export const InputDiv = styled.div`
   position: relative;
 `;
 
-export const BaseStyleInput = css<
-  Pick<BaseInputBoxProps, "status" | "maskStatus"> & { hintSize?: number }
->`
+export const BaseStyleInput = css<{ hintSize?: number; destructive?: boolean }>`
   display: flex;
   box-sizing: ${({ theme }) => theme.inputBox.boxSizing};
   flex-direction: row;
@@ -86,42 +91,39 @@ export const BaseStyleInput = css<
     }
   }};
 
-  border: ${({ theme, status, maskStatus }) =>
-    theme.inputBox[status || maskStatus || defaultStatus].border};
+  border: ${({ theme, destructive }) =>
+    theme.inputBox[destructive ? "destructive" : defaultStatus].border};
   border-radius: ${({ theme }) => theme.inputBox.borderRadius};
 
   background: ${({ theme }) => theme.inputBox.background};
-  box-shadow: ${({ theme, status, maskStatus }) =>
-    theme.inputBox[status || maskStatus || defaultStatus].boxShadow};
+  box-shadow: ${({ theme, destructive }) =>
+    theme.inputBox[destructive ? "destructive" : defaultStatus].boxShadow};
 
-  color: ${({ theme, status, maskStatus }) =>
-    theme.inputBox[status || maskStatus || defaultStatus].color};
+  color: ${({ theme, destructive }) =>
+    theme.inputBox[destructive ? "destructive" : defaultStatus].color};
   font-size: ${({ theme }) => theme.inputBox.fontSize};
 
   &:focus {
-    box-sizing: ${({ theme, status, maskStatus }) =>
-      theme.inputBox[status || maskStatus || defaultStatus].focused.boxSizing};
+    box-sizing: ${({ theme, destructive }) =>
+      theme.inputBox[destructive ? "destructive" : defaultStatus].focused
+        .boxSizing};
 
-    border: ${({ theme, status, maskStatus }) =>
-      theme.inputBox[status || maskStatus || defaultStatus].focused.border};
-    border-radius: ${({ theme, status, maskStatus }) =>
-      theme.inputBox[status || maskStatus || defaultStatus].focused
+    border: ${({ theme, destructive }) =>
+      theme.inputBox[destructive ? "destructive" : defaultStatus].focused
+        .border};
+    border-radius: ${({ theme, destructive }) =>
+      theme.inputBox[destructive ? "destructive" : defaultStatus].focused
         .borderRadius};
     outline: none;
 
     background: ${({ theme }) => theme.inputBox.background};
-    box-shadow: ${({ theme, status, maskStatus }) =>
-      theme.inputBox[status || maskStatus || defaultStatus].focused.boxShadow};
+    box-shadow: ${({ theme, destructive }) =>
+      theme.inputBox[destructive ? "destructive" : defaultStatus].focused
+        .boxShadow};
   }
 
   &::placeholder {
-    display: flex;
-    align-items: center;
-
-    color: ${(props: any) =>
-      props.disabled
-        ? props.theme.colors.neutral[300]
-        : props.theme.inputBox.placeholder.color};
+    color: ${(props) => props.theme.colors.neutral[400]};
   }
 
   &:disabled {
@@ -140,20 +142,20 @@ export const BaseStyleInput = css<
     background: ${({ theme }) => theme.inputBox.background};
     box-shadow: ${({ theme }) => theme.inputBox.disabled.boxShadow};
 
-    color: ${({ theme }) => theme.colors.neutral[300]};
+    color: ${({ theme }) => theme.colors.neutral[400]};
 
     cursor: not-allowed;
   }
 `;
 
 export const StyledInput = styled.input<
-  Pick<BaseInputBoxProps, "status"> & { hintSize?: number }
+  Pick<BaseInputBoxProps, "destructive"> & { hintSize?: number }
 >`
   ${BaseStyleInput}
 `;
 
 export const StyledMaskInput = styled(InputMask)<
-  Pick<BaseInputBoxProps, "maskStatus"> & { hintSize?: number }
+  Pick<BaseInputBoxProps, "destructive"> & { hintSize?: number }
 >`
   ${BaseStyleInput}
 `;

--- a/lib/components/InputBox/BaseInputBox.tsx
+++ b/lib/components/InputBox/BaseInputBox.tsx
@@ -2,7 +2,6 @@ import { BsExclamationTriangleFill } from "react-icons/bs";
 import React, { FC, useState } from "react";
 import {
   StyledDiv,
-  Helper,
   HelperDiv,
   Hint,
   HintDiv,
@@ -22,12 +21,12 @@ export interface BaseInputBoxProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   description?: string;
   hint?: {
-    content: string;
+    content: React.ReactNode;
     icon: React.ReactNode;
   };
-  status?: "info" | "destructive";
-  maskStatus?: "info" | "destructive";
+  destructive?: boolean;
   helper?: React.ReactNode;
+  helperIcon?: React.ReactNode;
   spaceAfter?: spacingTokens;
   spaced?: boolean;
   disableMinus?: boolean;
@@ -36,12 +35,19 @@ export interface BaseInputBoxProps
   mask?: string;
 }
 
+export const RequiredAsterisk = () => (
+  <Text as="span" type="overlineLarge" color="destructive" shade="600">
+    *
+  </Text>
+);
+
 const BaseInputBox: FC<BaseInputBoxProps> = ({
   spaced,
   description,
-  status,
+  destructive,
   hint,
   helper,
+  helperIcon,
   spaceAfter,
   ...inputProps
 }) => {
@@ -57,12 +63,12 @@ const BaseInputBox: FC<BaseInputBoxProps> = ({
   return (
     <StyledDiv spaced={spaced} spaceAfter={spaceAfter}>
       <Text as="label" htmlFor={inputID} spaceAfter="xsm" type="overlineXSmall">
-        {description}
+        {description} {inputProps.required && <RequiredAsterisk />}
       </Text>
       <InputDiv>
         {!inputProps?.children && !inputProps?.mask && (
           <StyledInput
-            status={status}
+            destructive={destructive}
             {...inputProps}
             hintSize={hintRef?.current?.clientWidth}
             type={showPassword ? "text" : inputProps.type}
@@ -73,7 +79,7 @@ const BaseInputBox: FC<BaseInputBoxProps> = ({
           <StyledMaskInput
             {...inputProps}
             hintSize={hintRef?.current?.clientWidth}
-            maskStatus={status}
+            destructive={destructive}
             mask={inputProps.mask}
             id={inputID}
           />
@@ -105,14 +111,21 @@ const BaseInputBox: FC<BaseInputBoxProps> = ({
       </InputDiv>
       {helper && (
         <HelperDiv>
-          {status === "destructive" && (
-            <HelperIcon status={status}>
+          {destructive && !helperIcon && (
+            <HelperIcon destructive={destructive}>
               <BsExclamationTriangleFill />
             </HelperIcon>
           )}
-          <Helper status={status} type="overlineXSmall">
+          {helperIcon && (
+            <HelperIcon destructive={destructive}>{helperIcon}</HelperIcon>
+          )}
+          <Text
+            type="paragraphSmall"
+            color={destructive ? "destructive" : "neutral"}
+            shade="400"
+          >
             {helper}
-          </Helper>
+          </Text>
         </HelperDiv>
       )}
     </StyledDiv>

--- a/lib/components/InputBox/DateInputBox.styled.ts
+++ b/lib/components/InputBox/DateInputBox.styled.ts
@@ -5,7 +5,9 @@ import { BaseInputBoxProps } from "./BaseInputBox";
 
 const defaultStatus = "info";
 
-export const StyledDatePicker = styled.div<Pick<BaseInputBoxProps, "status">>`
+export const StyledDatePicker = styled.div<
+  Pick<BaseInputBoxProps, "destructive">
+>`
   input {
     display: flex;
     box-sizing: ${({ theme }) => theme.inputBox.boxSizing};
@@ -17,33 +19,37 @@ export const StyledDatePicker = styled.div<Pick<BaseInputBoxProps, "status">>`
     height: ${({ theme }) => theme.inputBox.height};
     padding: ${({ theme }) => theme.inputBox.padding};
 
-    border: ${({ theme, status }) =>
-      theme.inputBox[status || defaultStatus].border};
+    border: ${({ theme, destructive }) =>
+      theme.inputBox[destructive ? "destructive" : defaultStatus].border};
     border-radius: ${({ theme }) => theme.inputBox.borderRadius};
 
     background: ${({ theme }) => theme.inputBox.background};
-    box-shadow: ${({ theme, status }) =>
-      theme.inputBox[status || defaultStatus].boxShadow};
+    box-shadow: ${({ theme, destructive }) =>
+      theme.inputBox[destructive ? "destructive" : defaultStatus].boxShadow};
 
-    color: ${({ theme, status }) =>
-      theme.inputBox[status || defaultStatus].color};
+    color: ${({ theme, destructive }) =>
+      theme.inputBox[destructive ? "destructive" : defaultStatus].color};
     font-family: ${({ theme }) => theme.typography.paragraphMedium.fontFamily};
     font-size: ${({ theme }) =>
       theme.typography.paragraphMedium.desktop.fontSize};
 
     &:focus {
-      box-sizing: ${({ theme, status }) =>
-        theme.inputBox[status || defaultStatus].focused.boxSizing};
+      box-sizing: ${({ theme, destructive }) =>
+        theme.inputBox[destructive ? "destructive" : defaultStatus].focused
+          .boxSizing};
 
-      border: ${({ theme, status }) =>
-        theme.inputBox[status || defaultStatus].focused.border};
-      border-radius: ${({ theme, status }) =>
-        theme.inputBox[status || defaultStatus].focused.borderRadius};
+      border: ${({ theme, destructive }) =>
+        theme.inputBox[destructive ? "destructive" : defaultStatus].focused
+          .border};
+      border-radius: ${({ theme, destructive }) =>
+        theme.inputBox[destructive ? "destructive" : defaultStatus].focused
+          .borderRadius};
       outline: none;
 
       background: ${({ theme }) => theme.inputBox.background};
-      box-shadow: ${({ theme, status }) =>
-        theme.inputBox[status || defaultStatus].focused.boxShadow};
+      box-shadow: ${({ theme, destructive }) =>
+        theme.inputBox[destructive ? "destructive" : defaultStatus].focused
+          .boxShadow};
     }
 
     &::placeholder {

--- a/lib/components/InputBox/DateInputBox.tsx
+++ b/lib/components/InputBox/DateInputBox.tsx
@@ -9,7 +9,6 @@ import InputMask from "react-input-mask";
 
 import {
   StyledDiv,
-  Helper,
   HelperDiv,
   Hint,
   HintDiv,
@@ -28,11 +27,12 @@ export interface DateInputBoxProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   description?: string;
   hint?: {
-    content: string;
+    content: React.ReactNode;
     icon: React.ReactNode;
   };
-  status?: "info" | "destructive";
+  destructive?: boolean;
   helper?: React.ReactNode;
+  helperIcon?: React.ReactNode;
   spaceAfter?: spacingTokens;
   spaced?: boolean;
   onChange?: any;
@@ -42,9 +42,10 @@ export interface DateInputBoxProps
 const DateInputBox: FC<DateInputBoxProps> = ({
   spaced,
   description,
-  status,
+  destructive,
   hint,
   helper,
+  helperIcon,
   spaceAfter,
   placeholder,
   ...inputProps
@@ -61,7 +62,7 @@ const DateInputBox: FC<DateInputBoxProps> = ({
       </Text>
 
       <InputDiv>
-        <StyledDatePicker status={status}>
+        <StyledDatePicker destructive={destructive}>
           {
             // @ts-ignore
             // typescript issue here, the date picker onChange event has a different type than the HTML input's event
@@ -92,14 +93,25 @@ const DateInputBox: FC<DateInputBoxProps> = ({
           </HintDiv>
         )}
       </InputDiv>
-      <HelperDiv>
-        {status === "destructive" && (
-          <HelperIcon status={status}>
-            <BsExclamationTriangleFill />
-          </HelperIcon>
-        )}
-        <Helper status={status}>{helper}</Helper>
-      </HelperDiv>
+      {helper && (
+        <HelperDiv>
+          {destructive && !helperIcon && (
+            <HelperIcon destructive={destructive}>
+              <BsExclamationTriangleFill />
+            </HelperIcon>
+          )}
+          {helperIcon && (
+            <HelperIcon destructive={destructive}>{helperIcon}</HelperIcon>
+          )}
+          <Text
+            type="paragraphSmall"
+            color={destructive ? "destructive" : "neutral"}
+            shade="400"
+          >
+            {helper}
+          </Text>
+        </HelperDiv>
+      )}
     </StyledDiv>
   );
 };

--- a/lib/components/InputBox/NumberInputBox.tsx
+++ b/lib/components/InputBox/NumberInputBox.tsx
@@ -4,7 +4,6 @@ import { BsExclamationTriangleFill, BsPlusLg, BsDashLg } from "react-icons/bs";
 import { BaseInputBoxProps } from "./BaseInputBox";
 import Button from "../Button";
 import {
-  Helper,
   HelperDiv,
   HelperIcon,
   Hint,
@@ -38,10 +37,11 @@ const StyledButton = styled(Button)`
 
 const NumberInputBox: FC<BaseInputBoxProps> = ({
   spaced,
-  status,
+  destructive,
   description,
   hint,
   helper,
+  helperIcon,
   disableMinus,
   disablePlus,
   spaceAfter,
@@ -59,10 +59,10 @@ const NumberInputBox: FC<BaseInputBoxProps> = ({
       ? +inputRef?.current?.value + inputValue
       : inputValue;
 
-    if (props.min && updatedValue < props.min) {
+    if (props.min && updatedValue < (props.min as number)) {
       updatedValue = +props.min;
     }
-    if (props.max && updatedValue > props.max) {
+    if (props.max && updatedValue > (props.max as number)) {
       updatedValue = +props.max;
     }
 
@@ -96,7 +96,11 @@ const NumberInputBox: FC<BaseInputBoxProps> = ({
           <BsDashLg />
         </StyledButton>
         <InputWrapper>
-          <StyledStyledInput status={status} {...props} ref={inputRef} />
+          <StyledStyledInput
+            destructive={destructive}
+            ref={inputRef}
+            {...props}
+          />
           {hint && (
             <HintDiv>
               <Hint disabled={props.disabled}>{hint.content}</Hint>
@@ -117,14 +121,25 @@ const NumberInputBox: FC<BaseInputBoxProps> = ({
           <BsPlusLg />
         </StyledButton>
       </NumberInputBoxWrapper>
-      <HelperDiv>
-        {status === "destructive" && (
-          <HelperIcon status={status}>
-            <BsExclamationTriangleFill />
-          </HelperIcon>
-        )}
-        <Helper status={status}>{helper}</Helper>
-      </HelperDiv>
+      {helper && (
+        <HelperDiv>
+          {destructive && !helperIcon && (
+            <HelperIcon destructive={destructive}>
+              <BsExclamationTriangleFill />
+            </HelperIcon>
+          )}
+          {helperIcon && (
+            <HelperIcon destructive={destructive}>{helperIcon}</HelperIcon>
+          )}
+          <Text
+            type="paragraphSmall"
+            color={destructive ? "destructive" : "neutral"}
+            shade="400"
+          >
+            {helper}
+          </Text>
+        </HelperDiv>
+      )}
     </StyledDiv>
   );
 };

--- a/lib/components/InputBox/PhoneInputBox.tsx
+++ b/lib/components/InputBox/PhoneInputBox.tsx
@@ -7,9 +7,7 @@ import styled from "styled-components";
 import BaseInputBox, { BaseInputBoxProps } from "./BaseInputBox";
 import { BaseStyleInput } from "./BaseInputBox.styled";
 
-const StyledPhoneInputBox = styled(PhoneInput)<
-  Pick<BaseInputBoxProps, "status">
->`
+const StyledPhoneInputBox = styled(PhoneInput)`
   .PhoneInput {
     position: relative;
 
@@ -19,7 +17,7 @@ const StyledPhoneInputBox = styled(PhoneInput)<
   & .PhoneInputCountry {
     z-index: 1;
     left: 16px;
-    height: 50px;
+    height: 40px;
   }
 
   & input {

--- a/lib/components/InputBox/TextArea.tsx
+++ b/lib/components/InputBox/TextArea.tsx
@@ -6,7 +6,7 @@ import BaseInputBox, { BaseInputBoxProps } from "./BaseInputBox";
 import { BaseStyleInput } from "./BaseInputBox.styled";
 import { spacingTokens } from "../../types/tokens";
 
-const StyledTextArea = styled.textarea<Pick<BaseInputBoxProps, "status">>`
+const StyledTextArea = styled.textarea<Pick<BaseInputBoxProps, "destructive">>`
   ${BaseStyleInput}
   height: unset;
 `;
@@ -14,13 +14,13 @@ const StyledTextArea = styled.textarea<Pick<BaseInputBoxProps, "status">>`
 export interface TextAreaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   description?: string;
+  destructive?: boolean;
   hint?: {
     content: string;
     icon: React.ReactNode;
   };
   helper?: React.ReactNode;
   spaceAfter?: spacingTokens;
-  status?: "info" | "destructive";
   value?: string | ReadonlyArray<string> | undefined;
   rows?: number;
   cols?: number;
@@ -30,7 +30,7 @@ const TextArea: FC<TextAreaProps> = ({
   id,
   value,
   onChange,
-  status,
+  destructive,
   description,
   hint,
   helper,
@@ -41,7 +41,7 @@ const TextArea: FC<TextAreaProps> = ({
   return (
     <BaseInputBox
       id={id}
-      status={status}
+      destructive={destructive}
       description={description}
       hint={hint}
       helper={helper}
@@ -51,7 +51,7 @@ const TextArea: FC<TextAreaProps> = ({
         id={id}
         value={value}
         onChange={onChange}
-        status={status}
+        destructive={destructive}
         placeholder={placeholder}
         {...props}
       />

--- a/lib/components/InputBox/__snapshots__/InputBox.test.tsx.snap
+++ b/lib/components/InputBox/__snapshots__/InputBox.test.tsx.snap
@@ -13,12 +13,13 @@ exports[`InputBox > get InputBox by label text 1`] = `
         type="overlineXSmall"
       >
         User Name
+         
       </label>
       <div
-        class="sc-dmctIk ggHTBC"
+        class="sc-hHTYSt cmimTA"
       >
         <input
-          class="sc-kgTSHT edUolb"
+          class="sc-dmctIk KBWSG"
           id="textId"
           type="text"
         />
@@ -41,12 +42,13 @@ exports[`InputBox > get Phone InputBox by label text 1`] = `
         type="overlineXSmall"
       >
         Phone Info
+         
       </label>
       <div
-        class="sc-dmctIk ggHTBC"
+        class="sc-hHTYSt cmimTA"
       >
         <div
-          class="sc-hhOBVt fEmiuK PhoneInput PhoneInput--focus"
+          class="sc-jIRcFI hQDPtv PhoneInput PhoneInput--focus"
         >
           <div
             class="PhoneInputCountry"
@@ -1325,12 +1327,14 @@ exports[`InputBox > renders InputBox properly 1`] = `
       color="neutral"
       for="pebbles__input__1"
       type="overlineXSmall"
-    />
+    >
+       
+    </label>
     <div
-      class="sc-dmctIk ggHTBC"
+      class="sc-hHTYSt cmimTA"
     >
       <input
-        class="sc-kgTSHT edUolb"
+        class="sc-dmctIk KBWSG"
         id="pebbles__input__1"
       />
     </div>
@@ -1349,11 +1353,11 @@ exports[`InputBox > renders Number InputBox properly 1`] = `
       type="overlineXSmall"
     />
     <div
-      class="sc-bYMpWt jjOoVb"
+      class="sc-ezOQGI ljJUjZ"
     >
       <button
         aria-label="decrease button"
-        class="sc-cwSeag jbRVZA sc-jIRcFI cUfmtV"
+        class="sc-iveFHk gCiVNH sc-ilhmMj dEwtoP"
       >
         <svg
           fill="currentColor"
@@ -1370,16 +1374,16 @@ exports[`InputBox > renders Number InputBox properly 1`] = `
         </svg>
       </button>
       <div
-        class="sc-ilhmMj gzYeiu"
+        class="sc-kMjNwy dtTnrB"
       >
         <input
-          class="sc-kgTSHT sc-kMjNwy edUolb hecmlh"
+          class="sc-dmctIk sc-bYMpWt KBWSG dLsoWk"
           type="number"
         />
       </div>
       <button
         aria-label="increase button"
-        class="sc-cwSeag jbRVZA sc-jIRcFI cUfmtV"
+        class="sc-iveFHk gCiVNH sc-ilhmMj dEwtoP"
       >
         <svg
           fill="currentColor"
@@ -1396,15 +1400,6 @@ exports[`InputBox > renders Number InputBox properly 1`] = `
         </svg>
       </button>
     </div>
-    <div
-      class="sc-fnGiBr iBISzI"
-    >
-      <p
-        class="sc-ksBlkl bnPQdW sc-fEXmlR liFtqA"
-        color="neutral"
-        type="paragraphMedium"
-      />
-    </div>
   </div>
 </div>
 `;
@@ -1419,12 +1414,14 @@ exports[`InputBox > renders Phone InputBox properly 1`] = `
       color="neutral"
       for="pebbles__input__2"
       type="overlineXSmall"
-    />
+    >
+       
+    </label>
     <div
-      class="sc-dmctIk ggHTBC"
+      class="sc-hHTYSt cmimTA"
     >
       <div
-        class="sc-hhOBVt fEmiuK PhoneInput"
+        class="sc-jIRcFI hQDPtv PhoneInput"
       >
         <div
           class="PhoneInputCountry"

--- a/lib/components/Select2/Select.styled.ts
+++ b/lib/components/Select2/Select.styled.ts
@@ -1,7 +1,8 @@
 import styled from "styled-components";
 
 export const DropdownIndicatorWrapper = styled.div`
-  padding: ${({ theme }) => theme.icons.spacing};
+  padding-right: 8px;
+  padding-left: 8px;
 
   color: ${({ theme }) => theme.icons.input.dropdown.color};
 `;

--- a/lib/components/Select2/Select.tsx
+++ b/lib/components/Select2/Select.tsx
@@ -11,14 +11,13 @@ import ReactSelect, {
   ValueContainerProps,
 } from "react-select";
 import styled, { ThemeContext } from "styled-components";
-import { Helper, HelperDiv, HelperIcon } from "../InputBox/BaseInputBox.styled";
+import { HelperDiv, HelperIcon } from "../InputBox/BaseInputBox.styled";
 import { CustomSelectProps } from "./Select.types";
 import ThemeType from "../../types/theme";
 import { DropdownIndicatorWrapper } from "./Select.styled";
 import { spacingTokens } from "../../types/tokens";
 import { Text } from "../Typography";
-
-const defaultStatus = "info";
+import { RequiredAsterisk } from "../InputBox/BaseInputBox";
 
 const { ValueContainer } = components;
 
@@ -31,7 +30,7 @@ export const StyledDiv = styled.div<{ spaceAfter?: spacingTokens }>`
   }
 `;
 
-const CustomValueContainer: FC<ValueContainerProps> = ({
+export const CustomValueContainer: FC<ValueContainerProps> = ({
   children,
   ...props
 }) => {
@@ -58,9 +57,11 @@ function Select<
   IsMulti extends boolean = false,
   Group extends GroupBase<Option> = GroupBase<Option>
 >({
-  status,
+  required,
   helper,
+  helperIcon,
   label,
+  destructive,
   spaceAfter,
   ...props
 }: Props<Option, IsMulti, Group> & CustomSelectProps) {
@@ -71,17 +72,32 @@ function Select<
       control: (provided, state) => {
         return {
           ...provided,
+          outline: state.isFocused
+            ? destructive
+              ? `0px 0px 0px 3px ${theme.colors.destructive[100]}`
+              : `0px 0px 0px 3px ${theme.colors.primary[100]}`
+            : "none",
           boxShadow: state.isFocused
-            ? `0px 0px 0px 3px ${theme.colors.primary[100]}`
-            : theme.inputBox[status || defaultStatus].boxShadow,
+            ? destructive
+              ? `0px 0px 0px 3px ${theme.colors.destructive[100]}`
+              : `0px 0px 0px 3px ${theme.colors.primary[100]}`
+            : theme.inputBox[destructive ? "destructive" : "info"].boxShadow,
           border: state.isFocused
-            ? theme.inputBox[status || defaultStatus].focused.border
-            : theme.inputBox[status || defaultStatus].border,
+            ? theme.inputBox[destructive ? "destructive" : "info"].focused
+                .border
+            : theme.inputBox[destructive ? "destructive" : "info"].border,
           fontFamily: theme.typography.paragraphMedium.fontFamily,
           fontWeight: theme.typography.paragraphMedium.desktop.weights.normal,
           fontSize: theme.typography.paragraphMedium.desktop.fontSize,
         };
       },
+      indicatorSeparator: (provided) => ({
+        ...provided,
+        margin: 0,
+        backgroundColor: destructive
+          ? theme.colors.destructive[400]
+          : theme.colors.neutral[200],
+      }),
       option: (provided) => ({
         ...provided,
         fontFamily: theme.typography.paragraphMedium.fontFamily,
@@ -125,7 +141,7 @@ function Select<
       },
       spacing: {
         baseUnit: 4,
-        controlHeight: 50,
+        controlHeight: 40,
         menuGutter: helper ? 24 : 3,
       },
     }),
@@ -142,10 +158,11 @@ function Select<
         spaceAfter="xsm"
         type="overlineXSmall"
       >
-        {label}
+        {label} {required && <RequiredAsterisk />}
       </Text>
       <ReactSelect
         {...props}
+        required={required}
         styles={customStyles}
         theme={selectTheme}
         inputId={selectID}
@@ -154,19 +171,28 @@ function Select<
           ValueContainer: CustomValueContainer as any,
           DropdownIndicator: () => (
             <DropdownIndicatorWrapper>
-              <BsChevronDown />
+              <BsChevronDown size={16} />
             </DropdownIndicatorWrapper>
           ),
         }}
       />
       {helper && (
         <HelperDiv>
-          {status === "destructive" && (
-            <HelperIcon status={status}>
+          {destructive && !helperIcon && (
+            <HelperIcon destructive={destructive}>
               <BsExclamationTriangleFill />
             </HelperIcon>
           )}
-          <Helper status={status}>{helper}</Helper>
+          {helperIcon && (
+            <HelperIcon destructive={destructive}>{helperIcon}</HelperIcon>
+          )}
+          <Text
+            type="paragraphSmall"
+            color={destructive ? "destructive" : "neutral"}
+            shade="400"
+          >
+            {helper}
+          </Text>
         </HelperDiv>
       )}
     </StyledDiv>

--- a/lib/components/Select2/Select.types.ts
+++ b/lib/components/Select2/Select.types.ts
@@ -2,8 +2,10 @@ import React from "react";
 import { spacingTokens } from "../../types/tokens";
 
 export interface CustomSelectProps {
-  status?: "info" | "destructive";
   label?: React.ReactNode;
   helper?: React.ReactNode;
+  helperIcon?: React.ReactNode;
   spaceAfter?: spacingTokens;
+  destructive?: boolean;
+  required?: boolean;
 }

--- a/lib/components/SelectAsync/SelectAsync.tsx
+++ b/lib/components/SelectAsync/SelectAsync.tsx
@@ -1,15 +1,16 @@
-import { BsExclamationTriangleFill } from "react-icons/bs";
+import { BsChevronDown, BsExclamationTriangleFill } from "react-icons/bs";
 import uniqueId from "lodash.uniqueid";
 import React, { useContext, useMemo } from "react";
 import { StylesConfig, Theme, GroupBase } from "react-select";
 import ReactSelectAsync, { AsyncProps } from "react-select/async";
 import styled, { ThemeContext } from "styled-components";
-import { Helper, HelperDiv, HelperIcon } from "../InputBox/BaseInputBox.styled";
+import { HelperDiv, HelperIcon } from "../InputBox/BaseInputBox.styled";
 import { CustomSelectProps } from "./SelectAsync.types";
 import { spacingTokens } from "../../types/tokens";
 import { Text } from "../Typography";
-
-const defaultStatus = "info";
+import { CustomValueContainer } from "../Select2/Select";
+import { DropdownIndicatorWrapper } from "../Select2/Select.styled";
+import { RequiredAsterisk } from "../InputBox/BaseInputBox";
 
 export const StyledDiv = styled.div<{ spaceAfter?: spacingTokens }>`
   margin-bottom: ${({ theme, spaceAfter }) =>
@@ -25,8 +26,10 @@ function SelectAsync<
   IsMulti extends boolean = false,
   Group extends GroupBase<Option> = GroupBase<Option>
 >({
-  status,
+  required,
+  destructive,
   helper,
+  helperIcon,
   spaceAfter,
   label,
   ...props
@@ -38,17 +41,32 @@ function SelectAsync<
       control: (provided, state) => {
         return {
           ...provided,
+          outline: state.isFocused
+            ? destructive
+              ? `0px 0px 0px 3px ${theme.colors.destructive[100]}`
+              : `0px 0px 0px 3px ${theme.colors.primary[100]}`
+            : "none",
           boxShadow: state.isFocused
-            ? `0px 0px 0px 3px ${theme.colors.primary[100]}`
-            : theme.inputBox[status || defaultStatus].boxShadow,
+            ? destructive
+              ? `0px 0px 0px 3px ${theme.colors.destructive[100]}`
+              : `0px 0px 0px 3px ${theme.colors.primary[100]}`
+            : theme.inputBox[destructive ? "destructive" : "info"].boxShadow,
           border: state.isFocused
-            ? theme.inputBox[status || defaultStatus].focused.border
-            : theme.inputBox[status || defaultStatus].border,
+            ? theme.inputBox[destructive ? "destructive" : "info"].focused
+                .border
+            : theme.inputBox[destructive ? "destructive" : "info"].border,
           fontFamily: theme.typography.paragraphMedium.fontFamily,
           fontWeight: theme.typography.paragraphMedium.desktop.weights.normal,
           fontSize: theme.typography.paragraphMedium.desktop.fontSize,
         };
       },
+      indicatorSeparator: (provided) => ({
+        ...provided,
+        margin: 0,
+        backgroundColor: destructive
+          ? theme.colors.destructive[400]
+          : theme.colors.neutral[200],
+      }),
       option: (provided) => ({
         ...provided,
         fontFamily: theme.typography.paragraphMedium.fontFamily,
@@ -59,6 +77,10 @@ function SelectAsync<
       menu: (provided) => ({
         ...provided,
         borderRadius: 0,
+      }),
+      placeholder: (provided) => ({
+        ...provided,
+        color: theme.colors.neutral[400],
       }),
     }),
     [status]
@@ -88,7 +110,7 @@ function SelectAsync<
       },
       spacing: {
         baseUnit: 4,
-        controlHeight: 50,
+        controlHeight: 40,
         menuGutter: helper ? 24 : 3,
       },
     }),
@@ -105,22 +127,40 @@ function SelectAsync<
         spaceAfter="xsm"
         type="overlineXSmall"
       >
-        {label}
+        {label} {required && <RequiredAsterisk />}
       </Text>
       <ReactSelectAsync
         {...props}
         styles={customStyles}
+        required={required}
         theme={selectTheme}
         inputId={selectID}
+        components={{
+          ValueContainer: CustomValueContainer as never,
+          DropdownIndicator: () => (
+            <DropdownIndicatorWrapper>
+              <BsChevronDown size={16} />
+            </DropdownIndicatorWrapper>
+          ),
+        }}
       />
       {helper && (
         <HelperDiv>
-          {status === "destructive" && (
-            <HelperIcon status={status}>
+          {destructive && !helperIcon && (
+            <HelperIcon destructive={destructive}>
               <BsExclamationTriangleFill />
             </HelperIcon>
           )}
-          <Helper status={status}>{helper}</Helper>
+          {helperIcon && (
+            <HelperIcon destructive={destructive}>{helperIcon}</HelperIcon>
+          )}
+          <Text
+            type="paragraphSmall"
+            color={destructive ? "destructive" : "neutral"}
+            shade="400"
+          >
+            {helper}
+          </Text>
         </HelperDiv>
       )}
     </StyledDiv>

--- a/lib/components/SelectAsync/SelectAsync.types.ts
+++ b/lib/components/SelectAsync/SelectAsync.types.ts
@@ -2,8 +2,10 @@ import React from "react";
 import { spacingTokens } from "../../types/tokens";
 
 export interface CustomSelectProps {
-  status?: "info" | "destructive";
+  required?: boolean;
+  destructive?: boolean;
   label?: React.ReactNode;
   helper?: React.ReactNode;
+  helperIcon?: React.ReactNode;
   spaceAfter?: spacingTokens;
 }

--- a/lib/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/lib/components/Table/__snapshots__/Table.test.tsx.snap
@@ -2,16 +2,16 @@
 
 exports[`Table > renders selected rows 1`] = `
 <table
-  class="sc-lllmON OlBHl"
+  class="sc-cwSeag iGwFxV"
 >
   <thead
-    class="sc-iJnaPW eCQUSR"
+    class="sc-lllmON cOPMjC"
   >
     <tr
-      class="sc-kMjNwy gOtxDB"
+      class="sc-bYMpWt hHNmTI"
     >
       <th
-        class="sc-ezOQGI betmzq"
+        class="sc-gikAfH gzeQOH"
       >
         <div
           style="display: flex; align-items: center; justify-content: unset;"
@@ -20,7 +20,7 @@ exports[`Table > renders selected rows 1`] = `
         </div>
       </th>
       <th
-        class="sc-ezOQGI betmzq"
+        class="sc-gikAfH gzeQOH"
       >
         <div
           style="display: flex; align-items: center; justify-content: unset;"
@@ -29,7 +29,7 @@ exports[`Table > renders selected rows 1`] = `
         </div>
       </th>
       <th
-        class="sc-ezOQGI betmzq"
+        class="sc-gikAfH gzeQOH"
       >
         <div
           style="display: flex; align-items: center; justify-content: unset;"
@@ -40,61 +40,61 @@ exports[`Table > renders selected rows 1`] = `
     </tr>
   </thead>
   <tbody
-    class="sc-gikAfH bEiNWC"
+    class="sc-iJnaPW hwvfhX"
   >
     <tr
-      class="sc-kMjNwy gOtxDB"
+      class="sc-bYMpWt hHNmTI"
     >
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       >
         Content A1
       </td>
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       >
         Content B1
       </td>
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       >
         Content C1
       </td>
     </tr>
     <tr
-      class="sc-kMjNwy cMbghf"
+      class="sc-bYMpWt ghLukq"
     >
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       >
         Content A2
       </td>
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       >
         Content B2
       </td>
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       >
         Content C2
       </td>
     </tr>
     <tr
-      class="sc-kMjNwy gOtxDB"
+      class="sc-bYMpWt hHNmTI"
     >
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       >
         Content A3
       </td>
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       >
         Content B3
       </td>
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       >
         Content C3
       </td>
@@ -105,16 +105,16 @@ exports[`Table > renders selected rows 1`] = `
 
 exports[`Table > renders with some content 1`] = `
 <table
-  class="sc-lllmON OlBHl"
+  class="sc-cwSeag iGwFxV"
 >
   <thead
-    class="sc-iJnaPW eCQUSR"
+    class="sc-lllmON cOPMjC"
   >
     <tr
-      class="sc-kMjNwy gOtxDB"
+      class="sc-bYMpWt hHNmTI"
     >
       <th
-        class="sc-ezOQGI betmzq"
+        class="sc-gikAfH gzeQOH"
       >
         <div
           style="display: flex; align-items: center; justify-content: unset;"
@@ -123,7 +123,7 @@ exports[`Table > renders with some content 1`] = `
         </div>
       </th>
       <th
-        class="sc-ezOQGI betmzq"
+        class="sc-gikAfH gzeQOH"
       >
         <div
           style="display: flex; align-items: center; justify-content: unset;"
@@ -146,7 +146,7 @@ exports[`Table > renders with some content 1`] = `
         </div>
       </th>
       <th
-        class="sc-ezOQGI betmzq"
+        class="sc-gikAfH gzeQOH"
       >
         <div
           style="display: flex; align-items: center; justify-content: unset;"
@@ -169,7 +169,7 @@ exports[`Table > renders with some content 1`] = `
         </div>
       </th>
       <th
-        class="sc-ezOQGI betmzq"
+        class="sc-gikAfH gzeQOH"
       >
         <div
           style="display: flex; align-items: center; justify-content: unset;"
@@ -192,58 +192,58 @@ exports[`Table > renders with some content 1`] = `
         </div>
       </th>
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       />
     </tr>
   </thead>
   <tbody
-    class="sc-gikAfH bEiNWC"
+    class="sc-iJnaPW hwvfhX"
   >
     <tr
-      class="sc-kMjNwy gOtxDB"
+      class="sc-bYMpWt hHNmTI"
     >
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       >
         Content A1
       </td>
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       >
         Content B1
       </td>
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       >
         Content C1
       </td>
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       />
     </tr>
     <tr
-      class="sc-kMjNwy imvxPg"
+      class="sc-bYMpWt ZnTbF"
     >
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       >
         Content A1
       </td>
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       >
         Content B1
       </td>
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       >
         Content C1
       </td>
       <td
-        class="sc-bYMpWt fbjkRd"
+        class="sc-ezOQGI eIClif"
       >
         <span
-          class="sc-ilhmMj goweTh"
+          class="sc-kMjNwy gtIgFu"
         >
           New
         </span>

--- a/lib/theme/light/theme.ts
+++ b/lib/theme/light/theme.ts
@@ -442,13 +442,14 @@ const inputBox: InputBox = {
   borderRadius: "8px",
   border: `1px solid ${neutral[200]}`,
   background: "white",
-  height: "50px",
+  height: "40px",
   width: "100%",
   fontSize: paragraphMedium.desktop.fontSize,
 
   destructive: {
     color: destructive[900],
-    border: `1px solid ${destructive[300]}`,
+    helperColor: destructive[400],
+    border: `1px solid ${destructive[500]}`,
     boxShadow: shadows.small,
     hintColor: neutral[500],
     focused: {
@@ -460,6 +461,7 @@ const inputBox: InputBox = {
   },
   info: {
     color: neutral[900],
+    helperColor: neutral[400],
     border: `1px solid ${neutral[200]}`,
     boxShadow: shadows.small,
     hintColor: neutral[500],
@@ -479,7 +481,6 @@ const inputBox: InputBox = {
     fontWeight: 600,
   },
   helper: {
-    color: neutral[500],
     fontStyle: "normal",
     fontSize: "14px",
     lineHeight: "20px",

--- a/lib/types/theme.ts
+++ b/lib/types/theme.ts
@@ -148,6 +148,7 @@ export interface InputBox {
 
   destructive: {
     color: CSS.Property.Color;
+    helperColor: CSS.Property.Color;
     border: CSS.Property.Border;
     boxShadow: CSS.Property.BoxShadow;
     hintColor: CSS.Property.Color;
@@ -155,6 +156,7 @@ export interface InputBox {
   };
   info: {
     color: CSS.Property.Color;
+    helperColor: CSS.Property.Color;
     border: CSS.Property.Border;
     boxShadow: CSS.Property.BoxShadow;
     hintColor: CSS.Property.Color;
@@ -173,7 +175,6 @@ export interface InputBox {
     lineHeight: CSS.Property.LineHeight;
   };
   helper: {
-    color: CSS.Property.Color;
     fontStyle: CSS.Property.FontStyle;
     fontSize: CSS.Property.FontSize;
     fontWeight: CSS.Property.FontWeight;

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "react-datepicker": "^4.7.0",
     "react-input-mask": "^2.0.4",
     "react-phone-number-input": "^3.2.2",
-    "react-select": "5.4.0"
+    "react-select": "5.7.3"
   },
   "stackblitz": {
     "startCommand": "npm run test:ui"

--- a/src/stories/components/inputBox/InputBox.stories.jsx
+++ b/src/stories/components/inputBox/InputBox.stories.jsx
@@ -29,20 +29,19 @@ Default.args = {
     content: "username",
     icon: <BsFillPersonBadgeFill />,
   },
-  status: "info",
   helper: "",
   placeholder: "provide your name here",
 };
 
-export const InputBoxError = Template.bind({});
-InputBoxError.args = {
+export const Destructive = Template.bind({});
+Destructive.args = {
   description: "Vehicle Id Number",
   hint: {
     content: "Some Hint",
     icon: <BsEnvelope />,
   },
   helper: "please provide the VIN number",
-  status: "destructive",
+  destructive: true,
   placeholder: "VIN",
   errorIcon: <BsExclamationTriangleFill />,
 };
@@ -54,7 +53,6 @@ HintedInputBox.args = {
     content: "e-mail",
     icon: <BsEnvelope />,
   },
-  status: "info",
   helper: "",
   placeholder: "no ads or spams.",
 };
@@ -66,11 +64,23 @@ DisabledInputBox.args = {
     content: "e-mail",
     icon: <BsEnvelope />,
   },
-  status: "info",
   helper: "",
   placeholder: "this input is disabled, sorry",
   disabled: true,
   value: "Some value here",
+};
+
+export const RequiredInputBox = Template.bind({});
+RequiredInputBox.args = {
+  required: true,
+  description: "This field is required",
+  placeholder: "Placeholder",
+  hint: {
+    content: "e-mail",
+    icon: <BsEnvelope />,
+  },
+  helper: "please provide your email",
+  helperIcon: <BsEnvelope />,
 };
 
 const InteractiveTemplate = (args) => {
@@ -95,7 +105,6 @@ InteractiveInputBox.args = {
       content: "e-mail",
       icon: <BsEnvelope />,
     },
-    status: "info",
     helper: "",
     placeholder: "no ads or spams.",
   },
@@ -110,7 +119,6 @@ InteractivePasswordInput.args = {
       content: "",
       icon: <BsLock />,
     },
-    status: "info",
     helper: "",
     placeholder: "input your password",
     isPassword: true,
@@ -125,7 +133,6 @@ DisabledPasswordInput.args = {
       content: "",
       icon: <BsLock />,
     },
-    status: "info",
     helper: "",
     placeholder: "input your password",
     isPassword: true,
@@ -144,7 +151,7 @@ MaskedInput.args = {
       content: "",
       icon: <BsCardList />,
     },
-    status: "destructive",
+    destructive: true,
     helper: "",
   },
 };

--- a/src/stories/components/select/Select.stories.tsx
+++ b/src/stories/components/select/Select.stories.tsx
@@ -36,7 +36,15 @@ Default.args = {};
 
 export const Destructive = Template.bind({});
 Destructive.args = {
-  status: "destructive",
+  destructive: true,
+  helper: "I am a destructive select",
+  label: "Destructive select",
+};
+
+export const Required = Template.bind({});
+Required.args = {
+  required: true,
+  label: "Required select",
 };
 
 export const WithLabel = Template.bind({});

--- a/src/stories/components/select/SelectAsync.stories.tsx
+++ b/src/stories/components/select/SelectAsync.stories.tsx
@@ -43,7 +43,15 @@ Default.args = {};
 
 export const Destructive = Template.bind({});
 Destructive.args = {
-  status: "destructive",
+  destructive: true,
+  helper: "I am a destructive select",
+  label: "Destructive select",
+};
+
+export const Required = Template.bind({});
+Required.args = {
+  required: true,
+  label: "Required select",
 };
 
 export const WithLabel = Template.bind({});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2215,6 +2215,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.2.6":
+  version: 1.2.6
+  resolution: "@floating-ui/core@npm:1.2.6"
+  checksum: e4aa96c435277f1720d4bc939e17a79b1e1eebd589c20b622d3c646a5273590ff889b8c6e126f7be61873cf8c4d7db7d418895986ea19b8b0d0530de32504c3a
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.0.1":
+  version: 1.2.9
+  resolution: "@floating-ui/dom@npm:1.2.9"
+  dependencies:
+    "@floating-ui/core": ^1.2.6
+  checksum: 16ae5e05a41c2ca16d51579d12729ca9d346241319f68ce5678f5fbeb9c4f9a16176c95089bbd7a0eb37c6ed90e5fd55a310ffc9948af7c841d5b8bfa0afe1b8
+  languageName: node
+  linkType: hard
+
 "@fontsource/archivo@npm:^4.5.3":
   version: 4.5.3
   resolution: "@fontsource/archivo@npm:4.5.3"
@@ -2526,7 +2542,7 @@ __metadata:
     react-input-mask: ^2.0.4
     react-jsonschema-form: ^1.8.1
     react-phone-number-input: ^3.2.2
-    react-select: 5.4.0
+    react-select: 5.7.3
     rollup-plugin-typescript: 1.0.1
     semantic-release: ^18.0.1
     semantic-release-slack-bot: ^3.5.2
@@ -14580,10 +14596,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"memoize-one@npm:^5.0.0":
-  version: 5.2.1
-  resolution: "memoize-one@npm:5.2.1"
-  checksum: a3cba7b824ebcf24cdfcd234aa7f86f3ad6394b8d9be4c96ff756dafb8b51c7f71320785fbc2304f1af48a0467cbbd2a409efc9333025700ed523f254cb52e3d
+"memoize-one@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "memoize-one@npm:6.0.0"
+  checksum: f185ea69f7cceae5d1cb596266dcffccf545e8e7b4106ec6aa93b71ab9d16460dd118ac8b12982c55f6d6322fcc1485de139df07eacffaae94888b9b3ad7675f
   languageName: node
   linkType: hard
 
@@ -17415,21 +17431,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-select@npm:5.4.0":
-  version: 5.4.0
-  resolution: "react-select@npm:5.4.0"
+"react-select@npm:5.7.3":
+  version: 5.7.3
+  resolution: "react-select@npm:5.7.3"
   dependencies:
     "@babel/runtime": ^7.12.0
     "@emotion/cache": ^11.4.0
     "@emotion/react": ^11.8.1
+    "@floating-ui/dom": ^1.0.1
     "@types/react-transition-group": ^4.4.0
-    memoize-one: ^5.0.0
+    memoize-one: ^6.0.0
     prop-types: ^15.6.0
     react-transition-group: ^4.3.0
+    use-isomorphic-layout-effect: ^1.1.2
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: da896f0f8b3c7f6250148ce9ded1ace60abb35b812be50d34cf7ba980b12ca75533c3bbfd9e722530cc0e70c17e8997c3c7e93743877d84c00b0d90e4da521e6
+  checksum: 9ffa75afb395e7077076521c529611494164ace0c6b1ceb249406991ac668947cfd0424812c15c2a45c792bb2794b22f2df93c4c2f2515962b7dfc7c91b029ec
   languageName: node
   linkType: hard
 
@@ -20594,6 +20612,18 @@ __metadata:
     "@types/react":
       optional: true
   checksum: fd9061817d4945af37fd79866b1fe96a09cafe873169a66ec699140b609c64db6c60512d94ec3ca90967837026ea6e6d003901c557693708aeee11d392418a9e
+  languageName: node
+  linkType: hard
+
+"use-isomorphic-layout-effect@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "use-isomorphic-layout-effect@npm:1.1.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: a6532f7fc9ae222c3725ff0308aaf1f1ddbd3c00d685ef9eee6714fd0684de5cb9741b432fbf51e61a784e2955424864f7ea9f99734a02f237b17ad3e18ea5cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Add support to the native HTML `required` prop
 - inserts a red `*` after the label
 - no longer necessary to mark inputs as optional
- `hint.content` no longer exists (only usage was to mark a field as optional)
- `hint.icon` is now just `icon`
- `helperIcon` now exists (before we only showed an ! icon for destructive fields)
- `status` prop is removed, now only a single boolean `destructive` prop is used to toggle that mode
- many styling changes to be in line with the latest version of the design system
- many styling fixes on all inputs, selects and textarea.